### PR TITLE
0.4.0 - Add support for Python3

### DIFF
--- a/durationpy/__init__.py
+++ b/durationpy/__init__.py
@@ -1,4 +1,3 @@
 # -*- coding: UTF-8 -*-
-
-from duration import to_str, from_str
+from .duration import to_str, from_str
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author       = 'Ilia Choly',
     author_email = 'ilia.choly@gmail.com',
     download_url = 'https://github.com/icholy/durationpy/tarball/0.3',
-    version      = '0.3',
+    version      = '0.4',
     packages     = ['durationpy'],
     license      = 'MIT'
 )


### PR DESCRIPTION
Feel free to sanity check this, but `python3 test.py` and `python test.py` both work for me now.