### PR TITLE
Disallow extra characters at start or end of string

### DIFF
--- a/test.py
+++ b/test.py
@@ -64,6 +64,11 @@ cases = [
   ["-.", False, 0],
   [".s", False, 0],
   ["+.s", False, 0],
+  ["X3h", False, 0],
+  ["3hY", False, 0],
+  ["X72h3m0.5msY", False, 0],
+  ["+X3h", False, 0],
+  ["-X3h", False, 0],
 
   # extended
   ["5y2mm", True, 5*year + 2*month],
@@ -82,7 +87,7 @@ class DurationTest(unittest.TestCase):
                     expected, actual,
                     "{}, expecting {}, got {}".format(input, expected, actual)) 
             else:
-                with self.assertRaises(durationpy.DurationError):
+                with self.assertRaises(durationpy.DurationError, msg=repr(input)):
                     durationpy.from_str(input)
 
     def test_formatter(self):


### PR DESCRIPTION
Currently `from_str` allows bogus durations like "X3hY" to be parsed, ignoring the extra characters "X" and "Y" at the start and the end instead of raising an error.

Prevent this by using `re.finditer` instead of `re.findall`, which allows us to check that the start() of the first match is at the start of the string, and the end() of the last match is at the end of the string.

We also need to move the sign parsing to before the regex matching.

Add some tests for these cases, and make it so you can see which case failed in the assertRaises testing.

In addition, move the regex compiling outside the function so it's only done once on import (a common Python idiom to get a small performance gain).

Fixes #11.