### PR TITLE
Fix Small Duration Formatting

### DIFF
--- a/durationpy/duration.py
+++ b/durationpy/duration.py
@@ -77,7 +77,7 @@ def to_str(delta, extended=False):
 
     total_seconds = delta.total_seconds()
     sign = "-" if total_seconds < 0 else ""
-    nanoseconds = abs(total_seconds * _second_size)
+    nanoseconds = round(abs(total_seconds * _second_size), 0)
 
     if abs(total_seconds) < 1:
         result_str = _to_str_small(nanoseconds, extended)
@@ -90,7 +90,6 @@ def to_str(delta, extended=False):
 def _to_str_small(nanoseconds, extended):
 
     result_str = ""
-    nanoseconds = round(nanoseconds, 0)
 
     if not nanoseconds:
         return "0"

--- a/durationpy/duration.py
+++ b/durationpy/duration.py
@@ -90,6 +90,7 @@ def to_str(delta, extended=False):
 def _to_str_small(nanoseconds, extended):
 
     result_str = ""
+    nanoseconds = round(nanoseconds, 0)
 
     if not nanoseconds:
         return "0"

--- a/test.py
+++ b/test.py
@@ -54,6 +54,10 @@ cases = [
   
   # large value
   ["52763797000ms", True, 52763797000 * millisecond],
+
+  # small value
+  # Use multiplication to preserve rounding errors
+  ["492us", True, timedelta(microseconds=492).total_seconds() * 1000],
   
   # errors
   ["", False, 0],


### PR DESCRIPTION
Greetings,

Currently, certain durations that end up with very small nanoseconds end up malformed such that `from_str(to_str(duration))` results in an exception.

Specifically:
```
>>> duration.to_str(timedelta(seconds=0.000492))
'492us5.82077e-11ns'

>>> duration.from_str(duration.to_str(timedelta(seconds=0.000492))
Exception: Unknown unit e in duration 492us5.82077e-11ns
```

The reason is that we format a very small number with `:g` which uses scientific notation once it becomes shorter than `:f`. We also can't use `:f` because it will results in things like `4.00000s`

We get the small number because of
```
>>> timedelta(seconds=0.000492).total_seconds() * durationpy.duration._second_size
492000.00000000006
```

I chose rounding nanoseconds because it should be the smallest unit of precision anyway but anything that fixes this is fine.
